### PR TITLE
 master-181125/Modified process synchronization packetContainer

### DIFF
--- a/src/main/java/Config/BeanConfig.java
+++ b/src/main/java/Config/BeanConfig.java
@@ -32,14 +32,8 @@ public class BeanConfig {
     }
 
     @Bean
-    public PacketContainer packetContainer() {
-        return new PacketContainer();
-    }
-
-    @Bean
     public JnetPcapWindows jnetPcapWindows() {
         JnetPcapWindows jnetPcapWindows = new JnetPcapWindows();
-        jnetPcapWindows.setPacketContainer(this.packetContainer());
         return jnetPcapWindows;
     }
 

--- a/src/main/java/Controller/NetworkController.java
+++ b/src/main/java/Controller/NetworkController.java
@@ -38,6 +38,7 @@ public class NetworkController {
     public ModelAndView analyze() throws IOException {
         ModelAndView modelAndView = new ModelAndView("index");
         modelAndView.addObject("systemInfos", windowSystemService.getSystemOsName());
+        modelAndView.addObject("id", networkService.getActiveDevice());
         return modelAndView;
     }
 

--- a/src/main/java/Network/PacketContainer.java
+++ b/src/main/java/Network/PacketContainer.java
@@ -3,6 +3,7 @@ package Network;
 import Network.model.Packet;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -12,6 +13,7 @@ import java.util.List;
 /**
  * Created by son on 2018-10-28.
  */
+@Slf4j
 public class PacketContainer {
     @Getter public List<Packet> packets = new ArrayList<>();
     @Getter @Setter private int totalListen;
@@ -19,10 +21,6 @@ public class PacketContainer {
 
     public void setPackets(final Packet packet) {
         this.packets.add(packet);
-    }
-
-    public synchronized void clearPackets() {
-        this.packets.clear();
     }
 
     /**

--- a/src/main/java/Pcap/JnetPcacp.java
+++ b/src/main/java/Pcap/JnetPcacp.java
@@ -13,7 +13,7 @@ public interface JnetPcacp {
      * 실시간 패킷 분석
      * @return
      */
-    public PacketContainer analyze();
+    public PacketContainer analyze(final PacketContainer packetContainer);
 
     public List<PcapIf> getNetworkDevices();
     public boolean activityDevice(final String id);

--- a/src/main/java/Pcap/JnetPcapWindows.java
+++ b/src/main/java/Pcap/JnetPcapWindows.java
@@ -13,7 +13,6 @@ import org.jnetpcap.packet.format.FormatUtils;
 import org.jnetpcap.protocol.network.Ip4;
 import org.jnetpcap.protocol.tcpip.Http;
 import org.jnetpcap.protocol.tcpip.Tcp;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.StringUtils;
 import java.util.ArrayList;
 import java.util.List;
@@ -23,7 +22,6 @@ import java.util.List;
  */
 @Slf4j
 public class JnetPcapWindows implements JnetPcacp {
-    private PacketContainer packetContainer;
     @Setter
     private PcapIf device;
     @Getter
@@ -34,11 +32,6 @@ public class JnetPcapWindows implements JnetPcacp {
     private static final int FLAG = Pcap.MODE_NON_PROMISCUOUS;
     private static final int TIMEOUT = 10 * 1000; // ms
     private static final StringBuilder ERROR_BUF = new StringBuilder();
-
-    @Autowired
-    public void setPacketContainer(final PacketContainer packetContainer) {
-        this.packetContainer = packetContainer;
-    }
 
     public JnetPcapWindows() {
         if (Pcap.findAllDevs(this.allDevices, ERROR_BUF) != Pcap.OK) {
@@ -62,7 +55,7 @@ public class JnetPcapWindows implements JnetPcacp {
      * @return PacketContainer
      */
     @Override
-    public PacketContainer analyze() {
+    public PacketContainer analyze(final PacketContainer packetContainer) {
         Ip4 ip4 = new Ip4();
         Tcp tcp = new Tcp();
         Http http = new Http();

--- a/src/main/java/Service/NetworkService.java
+++ b/src/main/java/Service/NetworkService.java
@@ -19,14 +19,12 @@ import java.util.*;
 @Slf4j
 @Service
 public class NetworkService {
-    private JnetPcapFactory jnetPcapFactory;
+    private JnetPcacp jnetPcacp;
     private Map<String, Boolean> deviceList = new HashMap<>();
 
     @Autowired
     public NetworkService(final JnetPcapFactory jnetPcapFactory) {
-        this.jnetPcapFactory = jnetPcapFactory;
-
-        JnetPcacp jnetPcacp = jnetPcapFactory.getPcap();
+        this.jnetPcacp = jnetPcapFactory.getPcap();
         List<PcapIf> pcapIfs = jnetPcacp.getNetworkDevices();
 
         for (PcapIf pcapIf : pcapIfs) {
@@ -35,12 +33,10 @@ public class NetworkService {
     }
 
     public PacketContainer analyze() throws IOException {
-        JnetPcacp jnetPcacp = jnetPcapFactory.getPcap();
         return jnetPcacp.analyze(new PacketContainer());
     }
 
     public JSONArray getNetworkDevices() {
-        JnetPcacp jnetPcacp = jnetPcapFactory.getPcap();
         List<PcapIf> devices = jnetPcacp.getNetworkDevices();
 
         JSONArray jsonArray = new JSONArray();
@@ -54,7 +50,6 @@ public class NetworkService {
     }
 
     public boolean activityDevice(final String id) {
-        JnetPcacp jnetPcacp = jnetPcapFactory.getPcap();
         if (!jnetPcacp.activityDevice(id)) {
             return false;
         }
@@ -63,7 +58,6 @@ public class NetworkService {
     }
 
     public String getActiveDevice() {
-        JnetPcacp jnetPcacp = jnetPcapFactory.getPcap();
         String id = "";
         for (Map.Entry<String, Boolean> device : deviceList.entrySet()) {
             if (!device.getValue()) {
@@ -80,7 +74,6 @@ public class NetworkService {
     }
 
     public boolean isEmptyDevice() {
-        JnetPcacp jnetPcacp = jnetPcapFactory.getPcap();
         return jnetPcacp.emptyDevice();
     }
 

--- a/src/main/java/Service/NetworkService.java
+++ b/src/main/java/Service/NetworkService.java
@@ -20,13 +20,11 @@ import java.util.*;
 @Service
 public class NetworkService {
     private JnetPcapFactory jnetPcapFactory;
-    private PacketContainer packetContainer;
     private Map<String, Boolean> deviceList = new HashMap<>();
 
     @Autowired
-    public NetworkService(final JnetPcapFactory jnetPcapFactory, final PacketContainer packetContainer) {
+    public NetworkService(final JnetPcapFactory jnetPcapFactory) {
         this.jnetPcapFactory = jnetPcapFactory;
-        this.packetContainer = packetContainer;
 
         JnetPcacp jnetPcacp = jnetPcapFactory.getPcap();
         List<PcapIf> pcapIfs = jnetPcacp.getNetworkDevices();
@@ -38,7 +36,7 @@ public class NetworkService {
 
     public PacketContainer analyze() throws IOException {
         JnetPcacp jnetPcacp = jnetPcapFactory.getPcap();
-        return jnetPcacp.analyze();
+        return jnetPcacp.analyze(new PacketContainer());
     }
 
     public JSONArray getNetworkDevices() {
@@ -77,9 +75,5 @@ public class NetworkService {
             }
         }
         return false;
-    }
-
-    public synchronized void clearPackets() {
-        packetContainer.clearPackets();
     }
 }

--- a/src/main/java/Service/NetworkService.java
+++ b/src/main/java/Service/NetworkService.java
@@ -62,15 +62,32 @@ public class NetworkService {
         return true;
     }
 
+    public String getActiveDevice() {
+        JnetPcacp jnetPcacp = jnetPcapFactory.getPcap();
+        String id = "";
+        for (Map.Entry<String, Boolean> device : deviceList.entrySet()) {
+            if (!device.getValue()) {
+                continue;
+            }
+            for (PcapIf pcapIf : jnetPcacp.getNetworkDevices()) {
+                if (!pcapIf.getName().equals(device.getKey())) {
+                    continue;
+                }
+                id = pcapIf.getDescription();
+            }
+        }
+        return id;
+    }
+
     public boolean isEmptyDevice() {
         JnetPcacp jnetPcacp = jnetPcapFactory.getPcap();
         return jnetPcacp.emptyDevice();
     }
 
     public boolean checkDevice() {
-        for (Map.Entry<String, Boolean> a : deviceList.entrySet()) {
-            if (a.getValue()) {
-                log.info("디바이스: " + a.getKey() + " 활성화 상태: " + a.getValue());
+        for (Map.Entry<String, Boolean> device : deviceList.entrySet()) {
+            if (device.getValue()) {
+                log.info("device: " + device.getKey() + " status: " + device.getValue());
                 return true;
             }
         }

--- a/src/main/java/aop/DetectPacketAop.java
+++ b/src/main/java/aop/DetectPacketAop.java
@@ -15,13 +15,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 public class DetectPacketAop {
     @Autowired NetworkService networkService;
 
-    @Before("execution(* Controller.NetworkController.detect())")
+    @Before("execution(* Controller.NetworkController.detect(..))")
     public void startDetectController() {
-        networkService.clearPackets();
         log.info("[Called] Detecting request from client");
     }
 
-    @After("execution(* Controller.NetworkController.detect())")
+    @After("execution(* Controller.NetworkController.detect(..))")
     public void updatePacketsDatabase() {
         log.info("[Update database] update packets to database");
     }

--- a/src/test/java/Pcap/JnetPcapTest.java
+++ b/src/test/java/Pcap/JnetPcapTest.java
@@ -1,6 +1,5 @@
 package Pcap;
 
-import Network.PacketContainer;
 import lombok.extern.slf4j.Slf4j;
 import org.jnetpcap.PcapIf;
 import org.junit.Before;
@@ -16,9 +15,7 @@ public class JnetPcapTest {
 
     @Before
     public void setUp() {
-        PacketContainer packetContainer = new PacketContainer();
         JnetPcapWindows jnetPcapWindows = new JnetPcapWindows();
-        jnetPcapWindows.setPacketContainer(packetContainer);
 
         JnetPcapFactory jnetPcapFactory = new JnetPcapFactory();
         jnetPcapFactory.setJnetPcapWindows(jnetPcapWindows);

--- a/web/WEB-INF/views/index.jsp
+++ b/web/WEB-INF/views/index.jsp
@@ -114,7 +114,16 @@
         </div>
       </div>
 
-      <h4 class="sub-header">Packet Table</h4>
+      <h4 class="sub-header">
+        <c:choose>
+          <c:when test="${id ne ''}">
+              ${id}
+          </c:when>
+          <c:otherwise>
+              Select network device...
+          </c:otherwise>
+        </c:choose>
+      </h4>
       <table class="table table-striped" style="
     margin-bottom: 0;">
         <thead>


### PR DESCRIPTION
    - 싱글턴으로 사용하고 있던 packetConatiner 제거
    - 리퀘스트 마다 packetConatiner 객체 생성 후 소멸되도록 수정
    - 네트워크 디바이스를 선택 했을 때, 대쉬보드에 해당 디바이스 명 표시하도록 작업함
    - JnetPcap를 지역 객체로 받아서 처리하도록 수정